### PR TITLE
add exclude for idrac virtual devices

### DIFF
--- a/storage_system_fastvps_monitoring.pl
+++ b/storage_system_fastvps_monitoring.pl
@@ -366,6 +366,11 @@ sub find_disks_without_parted {
 
         # Код ниже ожидает вот в таком виде
         $model = "$vendor $model";
+	
+	# Исключаем из рассмотрения виртуальные устройства от idrac
+	if ( $model =~ m/^idrac\s+virtual\s+\w+$/ ) {
+		next;
+	}
         
         my $device_size = get_device_size($block_device);
 


### PR DESCRIPTION
Add exclude for idrac virtual devices for find_disks_without_parted (parted not detect it already)

Befor fix
```
./storage_system_fastvps_monitoring.pl --detect
Device /dev/sda with type: raid model: lsi in state: optimal detected
Device /dev/sdb with type: hard_disk model: idrac virtual floppy detected
Device /dev/sr0 with type: hard_disk model: idrac virtual cd detected
```
after - 
```
./storage_system_fastvps_monitoring.pl --detect
Device /dev/sda with type: raid model: lsi in state: optimal detected
```