### PR TITLE
Fix for CentOS 7 with LSI

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -115,7 +115,7 @@ check_n_install_diag_tools() {
                 dpkg -i /tmp/megacli.deb
                 rm -f /tmp/megacli.deb
             ;;
-            centos)
+            centos*)
                 yum install -y "$DIAG_UTILITIES_REPO/megacli.rpm"
             ;;
             *)


### PR DESCRIPTION
DISTRIB can be debian, centos and centos7, but now that check fails for centos7.