### PR TITLE
Changed wget to verbose mode

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -254,10 +254,10 @@ _dl_and_check()
     # Adding --no-check-certificate on old OS
     case $os in
         Debian6 )
-            wget_param=(--no-check-certificate --quiet)
+            wget_param=(--no-check-certificate --verbose)
         ;;
         * )
-            wget_param=(--quiet)
+            wget_param=(--verbose)
         ;;
     esac
 


### PR DESCRIPTION
If everything goes OK, output is hidden anyway.
But if we have an error, we want to have it on our screen.