### PR TITLE
Skip GPG check for Debian 6

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -67,7 +67,7 @@ PKG_DEPS["rpm_new"]='wget libstdc++ smartmontools perl-Crypt-SSLeay perl-libwww-
 
 declare -A PKG_INSTALL
 PKG_INSTALL["deb"]='apt-get update -qq && apt-get install -qq'
-PKG_INSTALL["deb_old"]='apt-get update -o Acquire::Check-Valid-Until=false -qq && apt-get install -qq'
+PKG_INSTALL["deb_old"]='apt-get update -o Acquire::Check-Valid-Until=false -qq && apt-get install -qq --allow-unauthenticated'
 PKG_INSTALL["rpm_old"]='yum install -q -y'
 PKG_INSTALL["rpm_new"]='yum install -q -y'
 


### PR DESCRIPTION
GPG keys in archive.debian.org are getting old, and it causes troubles. So we have to skip the check for Debian 6.