### PR TITLE
Added DEBIAN_FRONTEND=noninteractive to install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,9 @@
 
 set -u
 
+# Disable interactive mode when configuring packages
+export DEBIAN_FRONTEND='noninteractive'
+
 # Setting text colors
 TXT_GRN='\e[0;32m'
 TXT_RED='\e[0;31m'


### PR DESCRIPTION
Added variable DEBIAN_FRONTEND=noninteractive to installation script.  
This fixes the installation script, which hangs at the stage of configuration of the postfix package on Ubuntu 18