### PR TITLE
Add filter for Transcend JetFlash - USB-flash with major 8

### DIFF
--- a/storage_system_fastvps_monitoring.pl
+++ b/storage_system_fastvps_monitoring.pl
@@ -290,6 +290,11 @@ sub find_disks_without_parted {
             next;
         }
 
+        # Skip JetFlash devices
+        if ( $model =~ m/^jetflash\s+transcend\s+\w+$/ ) {
+            next;
+        }
+
         my $device_size = get_device_size($block_device);
         my $device_name = get_device_path($block_device);
 


### PR DESCRIPTION
Добавление фильтра для флешки (конкретной)
Вообще по хорошему надо бы весь этот блок переформатировать и вынести в отдельную функцию по фильтрации по именам таких флешек и прочего, что по major не фильтруется.